### PR TITLE
Disable notification + CopyButton replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 1.0.1
 
-- Adding quotes decoded. Thanks to [M97Chahboun](https://github.com/M97Chahboun)
-- Code is now selectable using cursor. Thanks to [justinekatebe69](https://github.com/justinekatebe69)
+New features:
+
+- `displayCopyNotification` was added, so it can be dynamically adjusted, wether a notification should be shown when
+  the copy button was pressed. Its disabled by default, so this package can work with CupertinoApps without need for adjustments.
+- `copyButtonReplacement` allows for replacing the default copy button that is used.
 
 ## 1.0.0
 
-The initial release has DartCodeViewer null safety version of [dart_code_viwewer](https://pub.dev/packages/dart_code_viewer/)
+The initial release of DartCodeViewerX

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package is an updated safety version of [dart_code_viewer2](https://pub.dev/packages/dart_code_viewer2), which is a package, that is the null safety version of [dart_code_viewer](https://pub.dev/packages/dart_code_viewer). I will try my best to keep this updated! Hopefully nobody needs to create a new fork of this package...
 
-Update: The original author reached out and updated the package. I will keep this fork, though in case we need a quick update.
+Update: The original author reached out and updated the package. I will keep this fork, though in case we need a quick update.\
 Update to the Update: We need to do some custom stuff especially for the implementation used in `fluttershow_base` so keep that in mind.
 
 Join the discord for discussions about this package: [![](https://dcbadge.vercel.app/api/server/xC6wtbzZnP)](https://discord.gg/xC6wtbzZnP)
@@ -10,6 +10,11 @@ Join the discord for discussions about this package: [![](https://dcbadge.vercel
 # dart_code_viewer_x
 
 The `dart_code_viewer_x` package for Flutter allows you to easily show and copy dart code in your Flutter application.
+
+Additional features in this package:
+
+- Decide wether to toggle notifications for copying code
+- Provide your own copy button instead of using the default ElevatedButton
 
 ## Getting Started
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/dart_code_viewer.dart
+++ b/lib/src/dart_code_viewer.dart
@@ -69,6 +69,7 @@ class DartCodeViewer extends StatelessWidget {
     this.stringStyle,
     this.backgroundColor,
     this.copyButtonText,
+    this.displayNotification,
     this.showCopyButton,
     this.height,
     this.width,
@@ -94,6 +95,7 @@ class DartCodeViewer extends StatelessWidget {
     Color? backgroundColor,
     Text? copyButtonText,
     bool? showCopyButton,
+    bool? displayNotification,
     double? height,
     double? width,
   }) {
@@ -110,6 +112,7 @@ class DartCodeViewer extends StatelessWidget {
       backgroundColor: backgroundColor,
       copyButtonText: copyButtonText,
       showCopyButton: showCopyButton,
+      displayNotification: displayNotification,
       height: height,
       width: width,
     );
@@ -290,6 +293,11 @@ class DartCodeViewer extends StatelessWidget {
   /// default the button is showing.
   final bool? showCopyButton;
 
+  /// When copying the code, you can decide wether to display a notification
+  /// that you copied your code or not. This only works when using [MaterialApp]!
+  /// By default, this is set to false.
+  final bool? displayNotification;
+
   /// The height of the [DartCodeViewer] by default it uses the [MediaQuery.of(context).size.height]
   final double? height;
 
@@ -384,6 +392,7 @@ class DartCodeViewer extends StatelessWidget {
         width: dartCodeViewerThemeData.width,
         child: _DartCodeViewerPage(
           codifyString(data, dartCodeViewerThemeData),
+          displayNotification ?? false,
         ),
       ),
     );
@@ -453,8 +462,9 @@ class DartCodeViewer extends StatelessWidget {
 }
 
 class _DartCodeViewerPage extends StatelessWidget {
-  const _DartCodeViewerPage(this.code);
+  const _DartCodeViewerPage(this.code, this.displayNotification);
   final InlineSpan code;
+  final bool displayNotification;
 
   @override
   Widget build(BuildContext context) {
@@ -462,6 +472,8 @@ class _DartCodeViewerPage extends StatelessWidget {
     final _plainTextCode = _richTextCode.toPlainText();
 
     void _showSnackBarOnCopySuccess(dynamic result) {
+      if (!displayNotification) return;
+
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Copied to Clipboard'),
@@ -470,6 +482,8 @@ class _DartCodeViewerPage extends StatelessWidget {
     }
 
     void _showSnackBarOnCopyFailure(Object exception) {
+      if (!displayNotification) return;
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Failure to copy to clipboard: $exception'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_code_viewer_x
 description: A package to view Dart Code in your Flutter application. This
   package is null safety version of dart-code-viewer
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/lucas-goldner/Dart-Code-Viewer-X
 
 environment:


### PR DESCRIPTION
- It allows disabling notifications from when code was copied, which can also be used in a Cupertino app.
- Also adds a `copyButtonReplacement` widget that can be displayed instead of the default copy button.
- Also updated version and documentation so it can be pushed to pub.dev